### PR TITLE
fix: Update Go version in Dockerfile to 1.24-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Stage 1: Build the Go binary
-FROM golang:1.22-alpine AS builder
+# UPDATED THIS LINE from 1.22 to 1.24
+FROM golang:1.24-alpine AS builder
 
 # Set the working directory inside the container
 WORKDIR /app


### PR DESCRIPTION
Updated the Go builder image in the Dockerfile from `golang:1.22-alpine` to `golang:1.24-alpine`. This change aligns the Docker build environment with the Go version specified in the `go.mod` file (1.24.4).