### PR TITLE
feat: Add dashboard API endpoint

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -66,6 +66,9 @@ func main() {
 
 	// API Routes
 	r.Route("/api/v1", func(r chi.Router) {
+		// Public dashboard route
+		r.Get("/dashboard", apiHandler.HandleGetDashboard) // Added this line
+
 		r.Group(func(r chi.Router) {
 			r.Use(auth.JWTMiddleware(cfg.SupabaseJWTSecret, cfg.SupabaseServiceKey))
 			r.Post("/onboarding", apiHandler.OnboardingHandler)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -43,3 +43,18 @@ func (a *API) OnboardingHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(`{"message": "Profile updated successfully"}`))
 }
+
+func (a *API) HandleGetDashboard(w http.ResponseWriter, r *http.Request) {
+	// In a future step, we will get the userID from the auth middleware.
+	// For now, we can use a placeholder ID.
+	userID := "placeholder_user_id" // Or retrieve from context if auth.UserIDKey is already set by a middleware for this path
+
+	dashboardData, err := a.store.GetDashboardData(userID) // Corrected: a.store instead of s.Store
+	if err != nil {
+		http.Error(w, "Failed to retrieve dashboard data", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(dashboardData)
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -1,0 +1,55 @@
+// in internal/api/types.go
+package api
+
+type DashboardResponse struct {
+	WelcomeMessage string            `json:"welcomeMessage"`
+	Credits        string            `json:"credits"`
+	TestGen        TestGenCardData   `json:"testGen"`
+	Courses        CoursesCardData   `json:"courses"`
+	Quote          QuoteCardData     `json:"quote"`
+	News           NewsCardData      `json:"news"`
+	QuickLinks     QuickLinksCardData `json:"quickLinks"`
+}
+
+type TestGenCardData struct {
+	Title        string `json:"title"`
+	Subject      string `json:"subject"`
+	Chapters     string `json:"chapters"`
+	LastExam     string `json:"lastExam"`
+	PendingExams string `json:"pendingExams"`
+	ButtonText   string `json:"buttonText"`
+}
+
+type CoursesCardData struct {
+	Title             string `json:"title"`
+	EnrollmentStatus  string `json:"enrollmentStatus"`
+	TodaysFocus       string `json:"todaysFocus"`
+	ButtonText        string `json:"buttonText"`
+}
+
+type QuoteCardData struct {
+	Title      string `json:"title"`
+	Quote      string `json:"quote"`
+	Author     string `json:"author"`
+	ButtonText string `json:"buttonText"`
+}
+
+type NewsItem struct {
+	Text string `json:"text"`
+	Time string `json:"time"`
+}
+
+type NewsCardData struct {
+	Title string     `json:"title"`
+	Items []NewsItem `json:"items"`
+}
+
+type QuickLinkItem struct {
+	Text string `json:"text"`
+	Icon string `json:"icon"`
+}
+
+type QuickLinksCardData struct {
+	Title string          `json:"title"`
+	Links []QuickLinkItem `json:"links"`
+}

--- a/internal/store/database.go
+++ b/internal/store/database.go
@@ -3,6 +3,7 @@ package store
 
 import (
 	"context"
+	"github.com/Mohamed-squared/lyceum-backend/internal/api" // Assuming lyceum is the module name defined in go.mod
 	"github.com/jackc/pgx/v5/pgxpool"
 	"time"
 )
@@ -53,4 +54,50 @@ func (s *Store) UpdateUserProfile(ctx context.Context, userID string, data Onboa
 		data.GithubURL, time.Now(),
 	)
 	return err
+}
+
+func (s *Store) GetDashboardData(userID string) (*api.DashboardResponse, error) {
+	// In a future step, we will query the database using the userID.
+	// For now, return hardcoded mock data.
+
+	mockData := &api.DashboardResponse{
+		WelcomeMessage: "Welcome, Scholar!",
+		Credits:        "Scholar's Credits: 250",
+		TestGen: api.TestGenCardData{
+			Title:        "TestGen Snapshot",
+			Subject:      "Artin Abstract Algebra",
+			Chapters:     "12/15 Chapters Mastered",
+			LastExam:     "Last Exam: 88%",
+			PendingExams: "2 Pending PDF Exams",
+			ButtonText:   "Go to TestGen Dashboard",
+		},
+		Courses: api.CoursesCardData{
+			Title:            "Courses Snapshot",
+			EnrollmentStatus: "3 Courses Enrolled",
+			TodaysFocus:      "Focus: Complete Chapter 3 of Quantum Mechanics",
+			ButtonText:       "Go to My Courses",
+		},
+		Quote: api.QuoteCardData{
+			Title:      "Quote of the Day",
+			Quote:      "The only true wisdom is in knowing you know nothing.",
+			Author:     "– Socrates",
+			ButtonText: "Refresh",
+		},
+		News: api.NewsCardData{
+			Title: "Lyceum News",
+			Items: []api.NewsItem{
+				{Text: "New Course Released: Advanced Calculus", Time: "2 hours ago"},
+				{Text: "Community Event: Study Group this Friday", Time: "1 day ago"},
+			},
+		},
+		QuickLinks: api.QuickLinksCardData{
+			Title: "Quick Links",
+			Links: []api.QuickLinkItem{
+				{Text: "Generate Test", Icon: "/assets/icons/icon-test.svg"},
+				{Text: "Browse Courses", Icon: "/assets/icons/icon-courses.svg"},
+			},
+		},
+	}
+
+	return mockData, nil
 }


### PR DESCRIPTION
This commit introduces a new API endpoint `/api/v1/dashboard` to serve data for your dashboard.

The following changes were made:
- Created `internal/api/types.go` with Go structs for the API response.
- Added `GetDashboardData` method to `internal/store/database.go`, returning mock data for now.
- Added `HandleGetDashboard` handler to `internal/api/handlers.go` to process requests for dashboard data.
- Registered the new GET route `/api/v1/dashboard` in `cmd/server/main.go`.

The endpoint currently uses mock data and a placeholder userID. Future work will involve integrating with actual database queries and user authentication.