### PR TITLE
refactor: Standardize API structure and type locations

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -24,7 +24,7 @@ func (a *API) OnboardingHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var data store.OnboardingData
+	var data types.OnboardingData
 	if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return

--- a/internal/store/database.go
+++ b/internal/store/database.go
@@ -16,26 +16,8 @@ func New(db *pgxpool.Pool) *Store {
 	return &Store{db: db}
 }
 
-// OnboardingData mirrors the JSON payload from the frontend
-type OnboardingData struct {
-	DisplayName                   string   `json:"displayName"`
-	UserRole                      string   `json:"userRole"`
-	PreferredWebsiteLanguage      string   `json:"preferred_website_language"`
-	PreferredCourseExplanationLanguage string `json:"preferred_course_explanation_language"`
-	PreferredCourseMaterialLanguage  string `json:"preferred_course_material_language"`
-	Major                         string   `json:"major"`
-	MajorLevel                    string   `json:"major_level"`
-	StudiedSubjects               []string `json:"studied_subjects"`
-	InterestedMajors              []string `json:"interested_majors"`
-	Hobbies                       []string `json:"hobbies"`
-	SubscribedToNewsletter        bool     `json:"subscribed_to_newsletter"`
-	ReceiveQuotes                 bool     `json:"receive_quotes"`
-	Bio                           string   `json:"bio"`
-	GithubURL                     string   `json:"github_url"`
-}
-
 // UpdateUserProfile updates a user's profile after onboarding
-func (s *Store) UpdateUserProfile(ctx context.Context, userID string, data OnboardingData) error {
+func (s *Store) UpdateUserProfile(ctx context.Context, userID string, data types.OnboardingData) error {
 	query := `
 		UPDATE public.profiles
 		SET

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -53,3 +53,20 @@ type QuickLinksCardData struct {
 	Title string          `json:"title"`
 	Links []QuickLinkItem `json:"links"`
 }
+
+type OnboardingData struct {
+	DisplayName                      string   `json:"displayName"`
+	UserRole                         string   `json:"userRole"`
+	PreferredWebsiteLanguage         string   `json:"preferred_website_language"`
+	PreferredCourseExplanationLanguage string   `json:"preferred_course_explanation_language"`
+	PreferredCourseMaterialLanguage    string   `json:"preferred_course_material_language"`
+	Major                            string   `json:"major"`
+	MajorLevel                       string   `json:"major_level"`
+	StudiedSubjects                  []string `json:"studied_subjects"`
+	InterestedMajors                 []string `json:"interested_majors"`
+	Hobbies                          []string `json:"hobbies"`
+	SubscribedToNewsletter           bool     `json:"subscribed_to_newsletter"`
+	ReceiveQuotes                    bool     `json:"receive_quotes"`
+	Bio                              string   `json:"bio"`
+	GithubURL                        string   `json:"github_url"`
+}


### PR DESCRIPTION
This commit addresses final structural inconsistencies and type placements to resolve compilation errors and improve code organization.

The following changes were made:
- Moved the `OnboardingData` struct from `internal/store/database.go` to `internal/types/types.go` to centralize shared data types.
- Updated `internal/store/database.go` to remove the local `OnboardingData` definition and use `types.OnboardingData` in the `UpdateUserProfile` function.
- Updated `internal/api/handlers.go` to use `types.OnboardingData` in the `OnboardingHandler`.
- Verified that `cmd/server/main.go` correctly initializes and uses the `apiHandler` for routing, consistent with the `API` struct methods.

These changes ensure that all shared types are in a common package, handlers are consistently defined as methods of the `API` struct, and all package references are correct, leading to a cleaner and compilable codebase.