### PR TITLE
Fix: Use DATABASE_URL from environment for DB connection

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"github.com/Mohamed-squared/lyceum-backend/internal/api"
 	"github.com/Mohamed-squared/lyceum-backend/internal/auth"
-	"github.com/Mohamed-squared/lyceum-backend/internal/config"
+	"github.com/Mohamed-squared/lyceum-backend/internal/config" // Keep for JWT, Port etc.
 	"github.com/Mohamed-squared/lyceum-backend/internal/store"
 	"net/http"
 	"os"
@@ -19,45 +19,54 @@ import (
 )
 
 func main() {
-	ctx := context.Background()
+	ctx := context.Background() // Keep or use context.Background() where needed
 
-	// Load configuration
+	// Load config (which might include JWT Secret, ServerPort, etc.)
 	cfg, err := config.Load()
 	if err != nil {
-		log.Fatalf("could not load config: %v", err)
+		log.Fatalf("Could not load config: %v", err)
 	}
 
-	// Connect to database
-	dbpool, err := pgxpool.New(ctx, cfg.DatabaseURL)
+	// Get Database URL from environment
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		log.Fatal("DATABASE_URL environment variable is not set")
+	}
+
+	// Create a new database connection pool
+	dbpool, err := pgxpool.New(ctx, dbURL) // Use ctx (or context.Background())
 	if err != nil {
-		log.Fatalf("Unable to connect to database: %v\n", err)
+		log.Fatalf("Unable to create connection pool: %v\n", err) // Added \n for clarity
 	}
 	defer dbpool.Close()
 
+	// Ping the database to verify connection
+	if err := dbpool.Ping(ctx); err != nil { // Use ctx (or context.Background())
+		log.Fatalf("Unable to connect to database: %v\n", err) // Added \n for clarity
+	}
 	log.Println("Successfully connected to the database.")
 
-	// Setup dependencies
+	// Setup dependencies (dbStore, apiHandler using the new dbpool)
 	dbStore := store.New(dbpool)
 	apiHandler := api.New(dbStore)
 
-	// Determine port and listen address
+	// Determine port and listen address (can still use cfg.ServerPort as fallback)
 	port := os.Getenv("PORT")
 	if port == "" {
-		port = cfg.ServerPort
+		port = cfg.ServerPort // cfg might still be useful
 	}
 	if port == "" {
-		port = "8080"
+		port = "8080" // Default fallback
 	}
 	listenAddr := fmt.Sprintf("0.0.0.0:%s", port)
 
 	// Setup router
 	r := chi.NewRouter()
 
-	// Middleware
+	// Middleware (Logger, CORS - keep existing, ensure cfg is available if CORS needs it)
 	r.Use(middleware.Logger)
-	// Ensure CORS options match the issue's example EXACTLY
 	r.Use(cors.Handler(cors.Options{
-		AllowedOrigins:   []string{"https://*.vercel.app", "http://localhost:3000"}, // FROM ISSUE
+		AllowedOrigins:   []string{"https://*.vercel.app", "http://localhost:3000"},
 		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
 		ExposedHeaders:   []string{"Link"},
@@ -65,16 +74,13 @@ func main() {
 		MaxAge:           300,
 	}))
 
-	authMiddleware := auth.AuthMiddleware(cfg.SupabaseJWTSecret) // Define it once
+	// Auth Middleware (ensure cfg.SupabaseJWTSecret is available)
+	authMiddleware := auth.AuthMiddleware(cfg.SupabaseJWTSecret)
 
-	// API Routes
+	// API Routes (keep existing)
 	r.Route("/api/v1", func(r chi.Router) {
-		r.Use(authMiddleware) // Apply to the whole group
-
-		// Previously public dashboard route, now authenticated
+		r.Use(authMiddleware)
 		r.Get("/dashboard", apiHandler.HandleGetDashboard)
-
-		// Previously in a sub-group, now directly under /api/v1 with auth
 		r.Post("/onboarding", apiHandler.OnboardingHandler)
 	})
 


### PR DESCRIPTION
I've modified cmd/server/main.go to establish the database connection using the DATABASE_URL environment variable instead of relying on a value from the config file structure.

This change includes:
- Retrieving DATABASE_URL via os.Getenv().
- A fatal error log if DATABASE_URL is not set.
- Using the retrieved URL for pgxpool.New().
- A ping to the database to verify the connection upon startup.

This aligns with standard practices for configuring database connections in containerized and cloud environments.