### PR TITLE
Fix: Correct newline character in log.Fatalf call

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -31,8 +31,7 @@ func main() {
 	// Connect to database
 	dbpool, err := pgxpool.New(ctx, cfg.DatabaseURL)
 	if err != nil {
-		log.Fatalf("Unable to connect to database: %v
-", err)
+		log.Fatalf("Unable to connect to database: %v\n", err)
 	}
 	defer dbpool.Close()
 


### PR DESCRIPTION
The `log.Fatalf` call for database connection errors in `cmd/server/main.go` contained an incorrect newline representation. This commit replaces it with the proper `\n` escape sequence.

Previously, the line might have had a literal newline or was missing the newline character, which could lead to build errors or improperly formatted log output.

The corrected line is now:
`log.Fatalf("Unable to connect to database: %v\n", err)`

This ensures the Go code compiles correctly and the log message is followed by a newline as intended.