### PR TITLE
Feat: Add detailed error logging to dashboard handler

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -3,6 +3,7 @@ package api
 
 import (
 	"encoding/json"
+	"log" // Added
 	"github.com/Mohamed-squared/lyceum-backend/internal/auth"
 	"github.com/Mohamed-squared/lyceum-backend/internal/store"
 	"github.com/Mohamed-squared/lyceum-backend/internal/types"
@@ -55,7 +56,7 @@ func (a *API) HandleGetDashboard(w http.ResponseWriter, r *http.Request) {
 	dashboardData, err := a.store.GetDashboardData(r.Context(), userID)
 	if err != nil {
 		// Optional: Log the internal error for debugging
-		// log.Printf("Error getting dashboard data for user %s: %v", userID, err)
+		log.Printf("!!! DATABASE ERROR: Failed to get dashboard data for user %s: %v", userID, err)
 		http.Error(w, "Failed to retrieve dashboard data", http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
Added detailed error logging to the `HandleGetDashboard` function in `internal/api/handlers.go`. This will help in diagnosing 500 Internal Server Errors by logging the specific error message from the `GetDashboardData` function call before a generic 500 response is sent to the client.

Changes include:
- Imported the "log" package.
- Added a `log.Printf` statement within the error handling block of `a.store.GetDashboardData` to print the user ID and the detailed error.