### PR TITLE
Fix: Correct onboarding data save and add error logging

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -38,6 +38,7 @@ func (a *API) OnboardingHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := a.store.UpdateUserProfile(r.Context(), userID, data); err != nil {
+		log.Printf("!!! ONBOARDING ERROR: Failed to update profile for user %s: %v", userID, err)
 		http.Error(w, "Failed to update profile", http.StatusInternalServerError)
 		return
 	}

--- a/internal/store/database.go
+++ b/internal/store/database.go
@@ -30,7 +30,7 @@ func (s *Store) UpdateUserProfile(ctx context.Context, userID string, data types
 			major = $7, major_level = $8, studied_subjects = $9, interested_majors = $10,
 			hobbies = $11, subscribed_to_newsletter = $12, receive_quotes = $13, bio = $14,
 			github_url = $15, has_completed_onboarding = TRUE, updated_at = $16
-		WHERE id = $1;
+		WHERE id = $1::uuid;
 	`
 	_, err := s.db.Exec(ctx, query,
 		userID, data.DisplayName, data.UserRole, data.PreferredWebsiteLanguage,


### PR DESCRIPTION
This commit addresses two issues:

1.  Ensures your profile data is correctly saved during onboarding by explicitly casting the 'id' field to 'uuid' in the UPDATE query in `internal/store/database.go`. This prevents potential type mismatch errors with PostgreSQL.

2.  Adds detailed error logging to the `OnboardingHandler` in `internal/api/handlers.go`. If `UpdateUserProfile` fails, the error, along with the `userID`, will now be logged, facilitating easier debugging of onboarding issues.