### PR TITLE
feat: Implement Create Course API endpoint

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -83,6 +83,7 @@ func main() {
 		// Your authenticated routes go here
 		r.Post("/onboarding", apiHandler.OnboardingHandler)
 		r.Get("/dashboard", apiHandler.HandleGetDashboard) // Now also protected by authMiddleware
+		r.Post("/courses", apiHandler.CreateCourseHandler)
 	})
 
 	// Start server

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -103,3 +103,43 @@ func (a *API) HealthCheckHandler(w http.ResponseWriter, r *http.Request) {
 
 	json.NewEncoder(w).Encode(wrappedResponse)
 }
+
+// CreateCourseHandler handles the creation of a new course.
+func (a *API) CreateCourseHandler(w http.ResponseWriter, r *http.Request) {
+	// Get creator's user ID from the authenticated context
+	creatorID, err := auth.GetUserIDFromContext(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	// Decode the request body
+	var req types.CreateCourseRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// Validate the input
+	if req.Title == "" {
+		http.Error(w, "Title is required", http.StatusBadRequest)
+		return
+	}
+	if req.Visibility != "public" && req.Visibility != "private" {
+		http.Error(w, "Visibility must be 'public' or 'private'", http.StatusBadRequest)
+		return
+	}
+
+	// Call the store to create the course
+	newCourse, err := a.store.CreateCourse(r.Context(), creatorID, req)
+	if err != nil {
+		log.Printf("!!! COURSE CREATION ERROR: %v", err)
+		http.Error(w, "Failed to create course", http.StatusInternalServerError)
+		return
+	}
+
+	// Respond with success
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated) // 201 Created
+	json.NewEncoder(w).Encode(map[string]interface{}{"success": true, "data": newCourse})
+}

--- a/internal/store/database.go
+++ b/internal/store/database.go
@@ -149,3 +149,49 @@ func (s *Store) GetDashboardData(ctx context.Context, userID string) (*types.Das
 func (s *Store) Ping(ctx context.Context) error {
 	return s.db.Ping(ctx)
 }
+
+// CreateCourse inserts a new course and enrolls the creator as an instructor.
+func (s *Store) CreateCourse(ctx context.Context, creatorID string, data types.CreateCourseRequest) (*types.CourseResponse, error) {
+	// Start a new transaction
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("could not begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx) // Rollback in case of any error
+
+	// 1. Insert into the 'courses' table
+	courseQuery := `
+		INSERT INTO public.courses (creator_id, title, description, visibility)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id, creator_id, title, description, visibility, created_at;
+	`
+	var course types.CourseResponse
+	err = tx.QueryRow(ctx, courseQuery, creatorID, data.Title, data.Description, data.Visibility).Scan(
+		&course.ID,
+		&course.CreatorID,
+		&course.Title,
+		&course.Description,
+		&course.Visibility,
+		&course.CreatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not insert course: %w", err)
+	}
+
+	// 2. Insert into the 'enrollments' table
+	enrollmentQuery := `
+		INSERT INTO public.enrollments (user_id, course_id, role)
+		VALUES ($1, $2, 'instructor');
+	`
+	_, err = tx.Exec(ctx, enrollmentQuery, creatorID, course.ID)
+	if err != nil {
+		return nil, fmt.Errorf("could not enroll creator in course: %w", err)
+	}
+
+	// 3. Commit the transaction
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("could not commit transaction: %w", err)
+	}
+
+	return &course, nil
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,6 +1,8 @@
 // in internal/types/types.go
 package types // Changed from package api
 
+import "time"
+
 type DashboardResponse struct {
 	WelcomeMessage string            `json:"welcomeMessage"`
 	Credits        string            `json:"credits"`
@@ -73,4 +75,21 @@ type OnboardingData struct {
 	GithubURL                        string   `json:"github_url"`
 	ProfilePictureURL string `json:"profile_picture_url,omitempty"`
 	ProfileBannerURL  string `json:"profile_banner_url,omitempty"`
+}
+
+// CreateCourseRequest defines the payload for creating a new course.
+type CreateCourseRequest struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Visibility  string `json:"visibility"`
+}
+
+// CourseResponse defines the data returned after creating or fetching a course.
+type CourseResponse struct {
+	ID          string    `json:"id"`
+	CreatorID   string    `json:"creatorId"`
+	Title       string    `json:"title"`
+	Description string    `json:"description"`
+	Visibility  string    `json:"visibility"`
+	CreatedAt   time.Time `json:"createdAt"`
 }


### PR DESCRIPTION
This commit introduces the functionality for authenticated users to create new courses.

The following changes were made:
- Added `CreateCourseRequest` and `CourseResponse` types to `internal/types/types.go`.
- Implemented the `CreateCourse` method in `internal/store/database.go`, which atomically creates a course and enrolls the creator as an instructor using a database transaction.
- Added the `CreateCourseHandler` in `internal/api/handlers.go` to handle API requests for course creation, including input validation.
- Registered the `POST /api/v1/courses` route in `cmd/server/main.go` under the authenticated route group.

These changes allow you to create courses via the API, adhering to the defined API contract and database schema.